### PR TITLE
Validation Bug

### DIFF
--- a/src/CardForm.js
+++ b/src/CardForm.js
@@ -124,7 +124,6 @@ class CardForm extends Component {
           name="cvc"
           ref="cvc"
           type="tel"
-          pattern="\d*"
           hintText="CVC"
           validations={{
             isNumeric: true,

--- a/src/CardForm.js
+++ b/src/CardForm.js
@@ -87,7 +87,6 @@ class CardForm extends Component {
           name="number"
           ref="number"
           type="tel"
-          pattern="\d*"
           hintText="Card number"
           validations={{
             isValid: (otherValues, card) => {


### PR DESCRIPTION
Hey, 

I saw a little bug in Chrome where CC numbers on the CardForm were not showing up as valid. ie. was getting the "please match the requested format" validation error, even though it should have been fine. Just removing ` pattern="\d*"` in CardForm.js gets rid of the issue. Let me know if you think there's anything else that should be done. 

Thanks for an awesome component!